### PR TITLE
Port over CSSPropertyOperations

### DIFF
--- a/Animated.js
+++ b/Animated.js
@@ -929,6 +929,9 @@ function createAnimatedComponent(Component: any): any {
         if (this.refs[refName].setNativeProps) {
           var value = this._propsAnimated.getAnimatedValue();
           this.refs[refName].setNativeProps(value);
+        } else if (this.refs[refName].getDOMNode().setAttribute) {
+          var value = this._propsAnimated.getAnimatedValue();
+          var strStyle = React.CSSPropertyOperations.setValueForStyles(this.refs[refName].getDOMNode(), value.style, this.refs[refName]);
         } else {
           this.forceUpdate();
         }

--- a/react.js
+++ b/react.js
@@ -83,6 +83,7 @@ var React = {
   unmountComponentAtNode: ReactMount.unmountComponentAtNode,
   isValidElement: ReactElement.isValidElement,
   withContext: ReactContext.withContext,
+  CSSPropertyOperations: _dereq_(5),
 
   // Hook for JSX spread, don't use this for anything else.
   __spread: assign


### PR DESCRIPTION
Expose CSSPropertyOpertions off of React (temporarily). The CSSPropertyOperations required other files, it was easier to expose it than just copy over all the files manually. If this is an issue I can copy em over.
This version of Animated already returns transform as a string so no need to flatten transform, just apply with CSSPropertyOperations
